### PR TITLE
full department, latex, DataSpace link, class year is pub year

### DIFF
--- a/lib/orangetheses/fetcher.rb
+++ b/lib/orangetheses/fetcher.rb
@@ -60,6 +60,8 @@ module Orangetheses
         h = {}
         h['id'] = i['handle'][/[^\/]*$/]
         i['metadata'].each do |m|
+          m['value'] = map_department(m['value']) if m['key'] == 'pu.department'
+          next if m['value'].nil?
           if h[m['key']].nil?
             h[m['key']] = [m['value']]
           else
@@ -85,6 +87,63 @@ module Orangetheses
       resp = Faraday.get "#{@server}/communities/#{community_id}/collections"
       json = JSON.parse(resp.body)
       json.map {|i| i['id'].to_s}
+    end
+
+    def map_department(dept)
+      lc_authorized_departments[dept]
+    end
+
+    def lc_authorized_departments
+      {
+        "Art and Archaeology" => "Princeton University. Department of Art and Archaeology",
+        "Aeronautical Engineering" => "Princeton University. Department of Aeronautical Engineering",
+        "Anthropology" => "Princeton University. Department of Anthropology",
+        "Architecture School" => "Princeton University. School of Architecture",
+        "Astrophysical Sciences" => "Princeton University. Department of Astrophysical Sciences",
+        "Biochemical Sciences" => "Princeton University. Department of Biochemical Sciences",
+        "Biology" => "Princeton University. Department of Biology",
+        "Civil and Environmental Engineering" => "Princeton University. Department of Civil and Environmental Engineering",
+        "Civil Engineering and Operations Research" => "Princeton University. Department of Civil Engineering and Operations Research",
+        "Chemical and Biological Engineering" => "Princeton University. Department of Chemical and Biological Engineering",
+        "Chemistry" => "Princeton University. Department of Chemistry",
+        "Classics" => "Princeton University. Department of Classics",
+        "Comparative Literature" => "Princeton University. Department of Comparative Literature",
+        "Computer Science" => "Princeton University. Department of Computer Science",
+        "Creative Writing Program" => "Princeton University. Creative Writing Program ",
+        "East Asian Studies" => "Princeton University. Department of East Asian Studies",
+        "Economics" => "Princeton University. Department of Economics",
+        "Ecology and Evolutionary Biology" => "Princeton University. Department of Ecology and Evolutionary Biology",
+        "Electrical Engineering" => "Princeton University. Department of Electrical Engineering",
+        "Engineering and Applied Science" => "Princeton University. School of Engineering and Applied Science",
+        "English" => "Princeton University. Department of English",
+        "French and Italian" => "Princeton University. Department of French and Italian",
+        "Geosciences" => "Princeton University. Department of Geosciences",
+        "German" => "Princeton University. Department of Germanic Languages and Literatures",
+        "History" => "Princeton University. Department of History",
+        "Special Program in Humanities" => "Princeton University. Special Program in the Humanities",
+        "Independent Concentration" => "Princeton University Independent Concentration Program ",
+        "Mathematics" => "Princeton University. Department of Mathematics",
+        "Molecular Biology" => "Princeton University. Department of Molecular Biology",
+        "Mechanical and Aerospace Engineering" => "Princeton University. Department of Mechanical and Aerospace Engineering",
+        "Medieval Studies" => "Princeton University. Program in Medieval Studies",
+        "Modern Languages" => "Princeton University. Department of Modern Languages.",
+        "Music" => "Princeton University. Department of Music",
+        "Near Eastern Studies" => "Princeton University. Department of Near Eastern Studies",
+        "Operations Research and Financial Engineering" => "Princeton University. Department of Operations Research and Financial Engineering",
+        "Oriental Studies" => "Princeton University. Department of Oriental Studies",
+        "Philosophy" => "Princeton University. Department of Philosophy",
+        "Physics" => "Princeton University. Department of Physics",
+        "Politics" => "Princeton University. Department of Politics",
+        "Psychology" => "Princeton University. Department of Psychology",
+        "Religion" => "Princeton University. Department of Religion",
+        "Romance Languages and Literatures" => "Princeton University. Department of Romance Languages and Literatures",
+        "Slavic Languages and Literature" => "Princeton University. Department of Slavic Languages and Literatures",
+        "Sociology" => "Princeton University. Department of Sociology",
+        "Spanish and Portuguese Languages and Cultures" => "Princeton University. Department of Spanish and Portuguese Languages and Cultures",
+        "Statistics" => "Princeton University. Department of Statistics",
+        "Theater" => "Princeton University. Program in Theater",
+        "Woodrow Wilson School" => "Woodrow Wilson School of Public and International Affairs"
+      }
     end
 
   end

--- a/lib/orangetheses/indexer.rb
+++ b/lib/orangetheses/indexer.rb
@@ -21,11 +21,11 @@ module Orangetheses
       'dc.contributor.author' => ['author_display', 'author_s'],
       'dc.contributor.advisor' => ['advisor_display', 'author_s'],
       'dc.contributor' => ['contributor_display', 'author_s'],
-      'pu.department' => ['department_s'],
+      'pu.department' => ['department_display', 'author_s'],
       'dc.format.extent' => ['description_display'],
       'dc.rights.accessRights' => ['rights_reproductions_note_display'],
       'pu.location' => ['rights_reproductions_note_display'],
-      'pu.date.classyear' => ['class_year_s'],
+      'pu.date.classyear' => ['class_year_s', 'pub_date_start_sort', 'pub_date_end_sort'],
       'dc.description.abstract' => ['summary_note_display']
     }
 
@@ -137,7 +137,7 @@ module Orangetheses
       arks = dc_elements.select do |e|
         e.name == 'identifier' && e.text.start_with?('http://arks.princeton')
       end
-      arks.empty? ? nil : { arks.first.text => ['arks.princeton.edu'] }.to_json.to_s
+      arks.empty? ? nil : { arks.first.text => [dspace_display_text] }.to_json.to_s
     end
 
     def online_holding
@@ -179,17 +179,13 @@ module Orangetheses
     end
 
     def build_solr_hash(doc)
-      date = choose_date_hash(doc)
       h = {
         'id' => doc['id'],
-        'title_t' => first_or_nil(doc['dc.title']),
+        'title_t' => title_search_hash(doc['dc.title']),
         'title_citation_display' => first_or_nil(doc['dc.title']),
         'title_display' => first_or_nil(doc['dc.title']),
         'title_sort' => title_sort_hash(doc['dc.title']),
         'author_sort' => first_or_nil(doc['dc.contributor.author']),
-        'pub_date_display' => date,
-        'pub_date_start_sort' => date,
-        'pub_date_end_sort' => date,
         'electronic_access_1display' => ark_hash(doc['dc.identifier.uri']),
         'standard_no_1display' => non_ark_ids_hash(doc['dc.identifier.other']),
       }
@@ -214,8 +210,22 @@ module Orangetheses
       end
     end
 
+    # Take first title, strip out latex expressions when present to include along
+    # with non-normalized version (allowing users to get matches both when LaTex
+    # is pasted directly into the search box and when sub/superscripts are placed
+    # adjacent to regular characters
+    def title_search_hash(titles)
+      unless titles.nil?
+        title = titles.first
+        title.scan(/\\\(.*?\\\)/).each do |latex|
+          title = title.gsub(latex, latex.gsub(/[^\p{Alnum}]/, ''))
+        end
+        title == titles.first ? title : [titles.first, title]
+      end
+    end
+
     def ark_hash(arks)
-      arks.nil? ? nil : { arks.first => ['arks.princeton.edu'] }.to_json.to_s
+      arks.nil? ? nil : { arks.first => [dspace_display_text] }.to_json.to_s
     end
 
     def non_ark_ids_hash(non_ark_ids)
@@ -224,6 +234,10 @@ module Orangetheses
 
     def first_or_nil(field)
       field.nil? ? nil : field.first
+    end
+
+    def dspace_display_text
+      'DataSpace'
     end
 
     # this is kind of a mess...

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -20,6 +20,7 @@ module Orangetheses
           "parentCommunityList"=>nil,
           "metadata"=>[
             {"key"=>"dc.contributor", "value"=>"Wolff, Tamsen", "language"=>nil},
+            {"key"=>"dc.contributor", "value"=>"2nd contributor", "language"=>nil},
             {"key"=>"dc.contributor.advisor", "value"=>"Sandberg, Robert", "language"=>nil},
             {"key"=>"dc.contributor.author", "value"=>"Clark, Hillary", "language"=>nil},
             {"key"=>"dc.date.accessioned", "value"=>"2013-07-11T14:31:58Z", "language"=>nil},
@@ -33,7 +34,7 @@ module Orangetheses
             {"key"=>"dc.type", "value"=>"Princeton University Senior Theses", "language"=>nil},
             {"key"=>"pu.date.classyear", "value"=>"2013", "language"=>"en_US"},
             {"key"=>"pu.department", "value"=>"English", "language"=>"en_US"},
-            {"key"=>"pu.department", "value"=>"Theater", "language"=>"en_US"},
+            {"key"=>"pu.department", "value"=>"NA", "language"=>"en_US"},
             {"key"=>"pu.pdf.coverpage", "value"=>"SeniorThesisCoverPage", "language"=>nil},
             {"key"=>"dc.rights.accessRights", "value"=>"Walk-in Access...", "language"=>nil}
           ],
@@ -54,9 +55,14 @@ module Orangetheses
       end
 
       it "supports multiple values if metadata appears more than once" do
-        expect(subject['pu.department']).to include('English', 'Theater')
+        expect(subject['dc.contributor']).to include('Wolff, Tamsen', '2nd contributor')
       end
 
+      it "maps pu.department to LC authorized name, excludes values not in name list" do
+        expect(subject['pu.department']).to include('Princeton University. Department of English')
+        expect(subject['pu.department']).not_to include('NA')
+        expect(subject['pu.department'].length).to eq 1
+      end
     end
 
   end

--- a/spec/indexer_spec.rb
+++ b/spec/indexer_spec.rb
@@ -32,7 +32,7 @@ module Orangetheses
         "dc.title"=>["Dysfunction: A Play in One Act"],
         "dc.type"=>["Princeton University Senior Theses"],
         "pu.date.classyear"=>["2014"],
-        "pu.department"=>["English", "Theater"],
+        "pu.department"=>["Princeton University. Department of English", "Princeton University. Program in Theater"],
         "pu.pdf.coverpage"=>["SeniorThesisCoverPage"],
         "dc.rights.accessRights"=>["Walk-in Access..."]
       }
@@ -170,8 +170,9 @@ module Orangetheses
         ]
       }
       it 'gets the ark if there is one' do
+        dspace_display = (subject.send(:dspace_display_text))
         ark = "http://arks.princeton.edu/ark:/88435/dsp013t945q852"
-        expected = %Q({"#{ark}":["arks.princeton.edu"]})
+        expected = %Q({"#{ark}":["#{dspace_display}"]})
         expect(subject.send(:ark, elements)).to eq expected
       end
       it 'returns nil if there is not a ark' do
@@ -183,8 +184,9 @@ module Orangetheses
       let(:ark_doc) { doc['dc.identifier.uri'] }
       let(:no_ark) { nil }
       it 'gets the ark if there is one' do
+        dspace_display = (subject.send(:dspace_display_text))
         ark = ark_doc.first
-        expected = %Q({"#{ark}":["arks.princeton.edu"]})
+        expected = %Q({"#{ark}":["#{dspace_display}"]})
         expect(subject.send(:ark_hash, ark_doc)).to eq expected
       end
       it 'returns nil if there is not a ark' do
@@ -228,11 +230,21 @@ module Orangetheses
       end
     end
 
+    describe 'LaTex normalization' do
+      it 'strips out all non alpha-numeric in LaTex expressions' do
+        latex = '2D \\(^{1}\\)H-\\(^{14}\\)N HSQC inverse-detection experiments'
+        title_search = subject.send(:title_search_hash, [latex])
+        expect(title_search).to include(latex)
+        expect(title_search).to include('2D 1H-14N HSQC inverse-detection experiments')
+      end
+    end
+
     describe '#_map_rest_non_special_to_solr' do
       let(:h) { subject.send(:map_rest_non_special_to_solr, doc) }
       it 'adds the expected keys' do
         expect(h).to include('author_display' => doc['dc.contributor.author'])
-        author_facet = [doc['dc.contributor.author'], doc['dc.contributor'], doc['dc.contributor.advisor']].flatten
+        author_facet = [doc['dc.contributor.author'], doc['dc.contributor'],
+                        doc['dc.contributor.advisor'], doc['pu.department']].flatten
         expect(h['author_s']).to match_array(author_facet)
         expect(h).to include('rights_reproductions_note_display' => doc['dc.rights.accessRights'])
       end


### PR DESCRIPTION
 - Use `DataSpace` instead of `arks.princeton.edu` for link display text. Closes #15 
 - Use the class year as the publication year. Closes #16 
 - Map brief department names to lc authorized departments. Exclude departments not in lc authorized department list from index/display in author browse. Closes #14 
 - Includes a normalized and non-normalized version of titles with LaTex to improve search retrieval.