### PR TITLE
do not normalize call_number_browse_s field

### DIFF
--- a/lib/orangetheses/indexer.rb
+++ b/lib/orangetheses/indexer.rb
@@ -4,7 +4,6 @@ require 'chronic'
 require 'logger'
 require 'json'
 require 'iso-639'
-require 'lcsort'
 
 module Orangetheses
   class Indexer
@@ -204,7 +203,7 @@ module Orangetheses
         'electronic_access_1display' => ark_hash(doc),
         'restrictions_note_display' => embargo_display_text(doc),
         'call_number_display' => call_number(doc['dc.identifier.other']),
-        'call_number_browse_s' => Lcsort.normalize(call_number(doc['dc.identifier.other'])),
+        'call_number_browse_s' => call_number(doc['dc.identifier.other']),
         'language_facet' => code_to_language(doc['dc.language.iso'])
       }
       h.merge!(map_rest_non_special_to_solr(doc))

--- a/orangetheses.gemspec
+++ b/orangetheses.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "rsolr"
   spec.add_dependency "chronic"
-  spec.add_dependency "lcsort"
 end


### PR DESCRIPTION
The call_number_browse_s field is the display field in the call number browse. It shouldn't be normalized: https://pulsearch.princeton.edu/browse/call_numbers?q=AC102+27