### PR TITLE
use https for dspace

### DIFF
--- a/lib/orangetheses.rb
+++ b/lib/orangetheses.rb
@@ -4,14 +4,14 @@ module Orangetheses
   #$test = true
   # OAI
   SET = 'com_88435_dsp019c67wm88m'
-  PMH_SERVER = 'http://dataspace.princeton.edu/oai/request'
-  PMH_SERVER = 'http://updatespace.princeton.edu/oai/request' if $test
+  PMH_SERVER = 'https://dataspace.princeton.edu/oai/request'
+  PMH_SERVER = 'https://updatespace.princeton.edu/oai/request' if $test
   METADATA_PREFIX = 'oai_dc'
 
   # REST service
   COMMUNITY_HANDLE = '88435/dsp019c67wm88m'
-  SERVER_URL = 'http://dataspace.princeton.edu/rest'
-  SERVER_URL = 'http://updatespace.princeton.edu/rest' if $test
+  SERVER_URL = 'https://dataspace.princeton.edu/rest'
+  SERVER_URL = 'https://updatespace.princeton.edu/rest' if $test
   REST_LIMIT = 100
 
   autoload :Harvester, 'orangetheses/harvester'

--- a/lib/orangetheses/fetcher.rb
+++ b/lib/orangetheses/fetcher.rb
@@ -1,12 +1,14 @@
 require 'faraday'
 require 'json'
 require 'tmpdir'
+require 'openssl'
+OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 
 module Orangetheses
   class Fetcher
 
     # @param [Hash] opts  options to pass to the client
-    # @option opts [String] :server ('http://dataspace.princeton.edu/rest/')
+    # @option opts [String] :server ('https://dataspace.princeton.edu/rest/')
     # @option opts [String] :community ('267')
     def initialize(server: SERVER_URL,
                    community: COMMUNITY_HANDLE)


### PR DESCRIPTION
Update dspace urls to use the non-verified ssl connection.