### PR TITLE
adds african american studies department

### DIFF
--- a/lib/orangetheses/fetcher.rb
+++ b/lib/orangetheses/fetcher.rb
@@ -113,6 +113,7 @@ module Orangetheses
 
     def lc_authorized_departments
       {
+        "African American Studies" => "Princeton University. Department of African American Studies",
         "Art and Archaeology" => "Princeton University. Department of Art and Archaeology",
         "Aeronautical Engineering" => "Princeton University. Department of Aeronautical Engineering",
         "Anthropology" => "Princeton University. Department of Anthropology",


### PR DESCRIPTION
Allows newly created Department of African American Studies to display for theses records: https://catalog.princeton.edu/?f[author_s][]=Princeton+University.+Department+of+African+American+Studies