### PR TITLE
Switch to coveralls-reborn to see if we can get code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/orangetheses.gemspec
+++ b/orangetheses.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bixby'
   spec.add_development_dependency 'bundler', '>= 1.16.0', '< 3'
-  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'coveralls_reborn', '~> 0.23.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
We are running into this bug: https://github.com/lemurheavy/coveralls-ruby/issues/161

The error message is `undefined method coverage for SimpleCov::SourceFile`
According to the referenced bug report, this switch should fix the
problem.

Before:
![Screen Shot 2021-10-25 at 9 22 47 AM](https://user-images.githubusercontent.com/65608/138703566-36bdc743-e721-4200-ae97-b2807690e320.png)

After: 
![Screen Shot 2021-10-25 at 9 22 24 AM](https://user-images.githubusercontent.com/65608/138703603-52aba60e-4860-4119-8327-2137798bf969.png)

Fixes #66 
