### PR TITLE
Configure code coverage to exclude spec directory

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+require 'coveralls'
 require 'orangetheses'
 require 'pry-byebug'
-require 'coveralls'
+require 'simplecov'
 require 'webmock/rspec'
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 Coveralls.wear!
+
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter 'spec'
+end
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
Until we fix this, our code coverage is being artificially inflated.

Note that the coverage check on this PR is red, because coverage appears to have gone down. This is known and expected.

![Screen Shot 2021-10-25 at 9 38 50 AM](https://user-images.githubusercontent.com/65608/138706145-4a6c1a76-9bff-4939-9574-fa41073f947d.png)
