### PR TITLE
Do not check for lando environment from within a Rails application

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -25,4 +25,6 @@ def lando_env_path
   )
 end
 
-require lando_env_path
+# Set up a development environment unless we are within a Rails application, which presumably
+# has its own development environment
+require lando_env_path unless defined? Rails


### PR DESCRIPTION
Orangetheses checks lando to get information about locally running dev and test solrs. This is great when developing orangetheses in isolation, however, prior to this commit, orangetheses also did these checks whenever it was required within a Rails application. In bibdata, this meant that every time we ran rspec, both bibdata and orangetheses did a lando check, adding over a second to each rspec run.

This commit keeps the lando check when Orangetheses is on its own, but does not issue the check if it notices that it is inside a Rails application.